### PR TITLE
feat: ✨ Add `Measure-SecureStringWithKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] Measure-SecureStringWithKey
+
+### Added
+
+- `Measure-SecureStringWithKey` now check if `ConvertFrom-SecureString` is used
+  without a `-Key` parameter. If you don't use a key then it's use the DPAPI
+  which means the secret is user and machine bound.
+
+### Changes
+
+- Perf improvements to `Measure-TODOComment` ([#3]).
+
 ## [0.1.1] Use Tokens
 
 ### Changes
@@ -19,3 +31,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Measure-TODOComment` is a PSScriptAnalyzer rule to detect if a TODO style
   comment exists in your code.
+
+[#3]: https://github.com/HeyItsGilbert/GoodEnoughRules/pull/3

--- a/GoodEnoughRules/GoodEnoughRules.psd1
+++ b/GoodEnoughRules/GoodEnoughRules.psd1
@@ -12,7 +12,7 @@
     RootModule = 'GoodEnoughRules.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/GoodEnoughRules/Private/Get-CommandParameters.ps1
+++ b/GoodEnoughRules/Private/Get-CommandParameters.ps1
@@ -1,0 +1,25 @@
+function Get-CommandParameters {
+    param (
+        [System.Management.Automation.Language.CommandAst]
+        $Command
+    )
+
+    $commandElements = $CommandAst.CommandElements
+    #region Gather Parameters
+    # Create a hash to hold the parameter name as the key, and the value
+    $parameterHash = @{}
+    for($i=1; $i -lt $commandElements.Count; $i++){
+        # Switch on type
+        switch ($commandElements[$i].GetType().Name){
+            'CommandParameterAst' {
+                $parameterName = $commandElements[$i].ParameterName
+            }
+            default {
+                # Grab the string from the extent
+                $value = $commandElements[$i].SafeGetValue()
+                $parameterHash[$parameterName] = $value
+            }
+        }
+    }
+    return $parameterHash
+}

--- a/GoodEnoughRules/Public/Measure-SecureStringWithKey.ps1
+++ b/GoodEnoughRules/Public/Measure-SecureStringWithKey.ps1
@@ -1,0 +1,54 @@
+function Measure-SecureStringWithKey {
+    <#
+    .SYNOPSIS
+    Rule to detect if ConvertFrom-SecureString is used without a Key.
+    .DESCRIPTION
+    This rule detects if ConvertFrom-SecureString is used without a Key which
+    means the secret is user and machine bound.
+    .EXAMPLE
+    Measure-SecureStringWithKey -ScriptBlockAst $ScriptBlockAst
+
+    This will check if the given ScriptBlockAst contains any
+    ConvertFrom-SecureString commands without a Key parameter.
+    .PARAMETER ScriptBlockAst
+    The scriptblock AST to check.
+    .INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+    .OUTPUTS
+    [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+    .NOTES
+    None
+    #>
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $ScriptBlockAst
+    )
+
+    Begin {
+        $predicate = {
+            param($Ast)
+            $Ast -is [System.Management.Automation.Language.CommandAst] -and
+            $Ast.GetCommandName() -eq 'ConvertFrom-SecureString'
+        }
+    }
+
+    Process {
+        [System.Management.Automation.Language.Ast[]]$commands = $ScriptBlockAst.FindAll($predicate, $true)
+        $commands | ForEach-Object {
+            $command = $_
+            $parameterHash = Get-CommandParameters -Command $command
+            if (-not $parameterHash.ContainsKey('Key')) {
+                [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+                    Message = 'ConvertFrom-SecureString should be used with a Key.'
+                    Extent = $command.Extent
+                    Severity = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Severity]::Error
+                }
+            }
+        }
+    }
+}

--- a/GoodEnoughRules/Public/Measure-TODOComment.ps1
+++ b/GoodEnoughRules/Public/Measure-TODOComment.ps1
@@ -5,13 +5,13 @@ function Measure-TODOComment {
     .DESCRIPTION
     This rule detects if TODO style comments are present in the given ScriptBlockAst.
     .EXAMPLE
-    Measure-TODOComment -ScriptBlockAst $ScriptBlockAst
+    Measure-TODOComment -Token $Token
 
-    This will check if the given ScriptBlockAst contains any TODO comments.
+    This will check if the given Token contains any TODO comments.
     .PARAMETER Token
     The token to check for TODO comments.
     .INPUTS
-    [System.Management.Automation.Language.ScriptBlockAst]
+    [System.Management.Automation.Language.Token]
     .OUTPUTS
     [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
     .NOTES

--- a/docs/en-US/Measure-SecureStringWithKey.md
+++ b/docs/en-US/Measure-SecureStringWithKey.md
@@ -1,0 +1,77 @@
+---
+external help file: GoodEnoughRules-help.xml
+Module Name: GoodEnoughRules
+online version:
+schema: 2.0.0
+---
+
+# Measure-SecureStringWithKey
+
+## SYNOPSIS
+Rule to detect if ConvertFrom-SecureString is used without a Key.
+
+## SYNTAX
+
+```
+Measure-SecureStringWithKey [-ScriptBlockAst] <ScriptBlockAst> [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+This rule detects if ConvertFrom-SecureString is used without a Key.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Measure-SecureStringWithKey -ScriptBlockAst $ScriptBlockAst
+```
+
+This will check if the given ScriptBlockAst contains any
+ConvertFrom-SecureString commands without a Key parameter.
+
+## PARAMETERS
+
+### -ScriptBlockAst
+The scriptblock AST to check.
+
+```yaml
+Type: ScriptBlockAst
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### [System.Management.Automation.Language.ScriptBlockAst]
+## OUTPUTS
+
+### [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+## NOTES
+None
+
+## RELATED LINKS

--- a/tests/Measure-SecureStringWithKey.ps1
+++ b/tests/Measure-SecureStringWithKey.ps1
@@ -21,4 +21,14 @@ ConvertFrom-SecureString -SecureString $secureString
         $result.Count | Should -BeExactly 1
         $result[0].Message | Should -Be 'ConvertFrom-SecureString should be used with a Key.'
     }
+
+    It 'does not detect correct usage' {
+        $fakeScript = @'
+$secureString = 'Hello, World!' | ConvertTo-SecureString -AsPlainText -Force
+ConvertFrom-SecureString -SecureString $secureString -Key (1..16)
+'@
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($fakeScript, [ref]$null, [ref]$null)
+        $result = Measure-TODOComment -ScriptBlockAst $ast
+        $results | Should -BeNullOrEmpty
+    }
 }

--- a/tests/Measure-SecureStringWithKey.ps1
+++ b/tests/Measure-SecureStringWithKey.ps1
@@ -1,0 +1,24 @@
+Describe 'Measure-TODOComment' {
+    BeforeAll {
+        $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+        $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'
+        $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+        $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+        $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+
+        # Get module commands
+        # Remove all versions of the module from the session. Pester can't handle multiple versions.
+        Get-Module $env:BHProjectName | Remove-Module -Force -ErrorAction Ignore
+        Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+    }
+    It 'Detects missing key' {
+        $fakeScript = @'
+$secureString = 'Hello, World!' | ConvertTo-SecureString -AsPlainText -Force
+ConvertFrom-SecureString -SecureString $secureString
+'@
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($fakeScript, [ref]$null, [ref]$null)
+        $result = Measure-TODOComment -ScriptBlockAst $ast
+        $result.Count | Should -BeExactly 1
+        $result[0].Message | Should -Be 'ConvertFrom-SecureString should be used with a Key.'
+    }
+}


### PR DESCRIPTION
* Introduced `Measure-SecureStringWithKey` to detect usage of `ConvertFrom-SecureString` without a `-Key` parameter.
* Improved performance of `Measure-TODOComment`.
* Updated module version to `0.2.0`.

