### PR TITLE
fix: 🐛 Update AST search logic to resolve duplicate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.1] 2025-12-14
+
+### Fixed
+
+- `Measure-BasicWebRequestProperty`: AST search modified to fix duplicate errors
+  due to recursive search.
+- `Measure-InvokeWebRequestWithoutBasic`: AST search modified to fix duplicate
+  errors due to recursive search.
+
 ## [0.3.0] 2025-12-13
 
 ### Added

--- a/GoodEnoughRules/GoodEnoughRules.psd1
+++ b/GoodEnoughRules/GoodEnoughRules.psd1
@@ -12,7 +12,7 @@
     RootModule = 'GoodEnoughRules.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.3.0'
+    ModuleVersion = '0.3.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/GoodEnoughRules/Public/Measure-BasicWebRequestProperty.ps1
+++ b/GoodEnoughRules/Public/Measure-BasicWebRequestProperty.ps1
@@ -77,7 +77,7 @@ function Measure-BasicWebRequestProperty {
 
     process {
         # Find all member expression ASTs that match our criteria
-        [System.Management.Automation.Language.Ast[]]$memberReads = $ScriptBlockAst.FindAll($iwrMemberRead, $true)
+        [System.Management.Automation.Language.Ast[]]$memberReads = $ScriptBlockAst.FindAll($iwrMemberRead, $false)
         foreach ($memberRead in $memberReads) {
             # ParenExpression would be the whole line: (iwr -Uri ... -UseBasicParsing).Foo
             $parenExpression = $memberRead.Parent.Parent
@@ -89,7 +89,7 @@ function Measure-BasicWebRequestProperty {
             }
         }
         # Find all assignment ASTs that match our criteria
-        [System.Management.Automation.Language.Ast[]]$assignments = $ScriptBlockAst.FindAll($varAssignPredicate, $true)
+        [System.Management.Automation.Language.Ast[]]$assignments = $ScriptBlockAst.FindAll($varAssignPredicate, $false)
         # Now use that to search for var reads of the assigned variable
         foreach ($assignment in $assignments) {
             $variableName = $assignment.Left.VariablePath.UserPath

--- a/GoodEnoughRules/Public/Measure-InvokeWebRequestWithoutBasic.ps1
+++ b/GoodEnoughRules/Public/Measure-InvokeWebRequestWithoutBasic.ps1
@@ -40,7 +40,7 @@ function Measure-InvokeWebRequestWithoutBasic {
     }
 
     process {
-        [System.Management.Automation.Language.Ast[]]$commands = $ScriptBlockAst.FindAll($predicate, $true)
+        [System.Management.Automation.Language.Ast[]]$commands = $ScriptBlockAst.FindAll($predicate, $false)
         $commands | ForEach-Object {
             Write-Verbose "Analyzing command: $($_.GetCommandName())"
             $command = $_

--- a/build.ps1
+++ b/build.ps1
@@ -8,14 +8,14 @@ param(
             switch ($Parameter) {
                 'Task' {
                     if ([string]::IsNullOrEmpty($WordToComplete)) {
-                        Get-PSakeScriptTasks -buildFile $psakeFile | Select-Object -ExpandProperty Name
+                        Get-PSakeScriptTasks -BuildFile $psakeFile | Select-Object -ExpandProperty Name
                     } else {
-                        Get-PSakeScriptTasks -buildFile $psakeFile |
+                        Get-PSakeScriptTasks -BuildFile $psakeFile |
                             Where-Object { $_.Name -match $WordToComplete } |
                             Select-Object -ExpandProperty Name
                     }
                 }
-                Default {
+                default {
                 }
             }
         })]
@@ -55,10 +55,11 @@ if ($Bootstrap.IsPresent) {
 # Execute psake task(s)
 $psakeFile = './psakeFile.ps1'
 if ($PSCmdlet.ParameterSetName -eq 'Help') {
-    Get-PSakeScriptTasks -buildFile $psakeFile |
+    Get-PSakeScriptTasks -BuildFile $psakeFile |
         Format-Table -Property Name, Description, Alias, DependsOn
 } else {
+    Invoke-PSDepend -Path './requirements.psd1' -Import -Force -WarningAction SilentlyContinue
     Set-BuildEnvironment -Force
-    Invoke-psake -buildFile $psakeFile -taskList $Task -NoLogo -properties $Properties -parameters $Parameters
+    Invoke-psake -buildFile $psakeFile -taskList $Task -nologo -properties $Properties -parameters $Parameters
     exit ([int](-not $psake.build_success))
 }

--- a/tests/Measure-SecureStringWithKey.ps1
+++ b/tests/Measure-SecureStringWithKey.ps1
@@ -1,7 +1,7 @@
 Describe 'Measure-TODOComment' {
     BeforeAll {
         if ( -not $env:BHPSModuleManifest ) {
-            .\build.ps1 -Task Build -Verbose
+            Set-BuildEnvironment -Path "$PSScriptRoot\.." -Force
         }
         $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
         $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'

--- a/tests/Measure-TODOComment.tests.ps1
+++ b/tests/Measure-TODOComment.tests.ps1
@@ -1,7 +1,7 @@
 Describe 'Measure-TODOComment' {
     BeforeAll {
         if ( -not $env:BHPSModuleManifest ) {
-            .\build.ps1 -Task Build -Verbose
+            Set-BuildEnvironment -Path "$PSScriptRoot\.." -Force
         }
         $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
         $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'

--- a/tests/fixtures/ExampleFunction.ps1
+++ b/tests/fixtures/ExampleFunction.ps1
@@ -1,0 +1,20 @@
+function Get-Example {
+    [CmdletBinding()]
+    param ()
+
+    begin {
+        $beginIWR = Invoke-WebRequest -Uri "https://example.com"
+    }
+
+    process {
+        $processIWR = Invoke-WebRequest -Uri "https://example.org"
+        $processIWR
+        $badParam = Invoke-WebRequest -Uri "https://example.net" -UseBasicParsing
+        $badParam.Forms
+    }
+
+    end {
+        $beginIWR.Forms
+        $badParam.AllElements
+    }
+}


### PR DESCRIPTION
* Modified `Measure-BasicWebRequestProperty` and `Measure-InvokeWebRequestWithoutBasic` to fix duplicate errors caused by recursive AST searches.
* Updated `CHANGELOG.md` for version 0.3.1 to reflect these fixes.
* Added tests to ensure proper detection of method usage with `Invoke-WebRequest`.

Fixes #7 
